### PR TITLE
feat: enhance support for external account binding with EAB #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Usage:
   dnsacme [flags]
 
 Examples:
-  dnsacme --domain='*.example.com' --dns=cloudflare --dns-config=CLOUDFLARE_API_TOKEN=xxxxxxxxxxxxxx
+  dnsacme --domain='*.example.com' --email='your.example.com' --dns=cloudflare --dns-config=CLOUDFLARE_API_TOKEN=xxxxxxxxxxxxxx
 
 Flags:
   -d, --domain strings              ACME cert domains
-  -m, --email string                ACME email (default "caddy@zerossl.com")
-      --storage-dir string          ACME cert status storage directory (default "/Users/kovacs/Library/Application Support/dnsacme")
+  -m, --email string                ACME email
+      --storage-dir string          ACME cert status storage directory (default "/root/.config/certmagic")
   -t, --key-type string             ACME cert key type (default "P384")
   -p, --dns string                  ACME DNS provider
       --dns-config stringToString   ACME DNS provider config map (default [])
@@ -35,8 +35,11 @@ Flags:
       --obtaining-hook string       CertMagic obtaining hook command
       --obtained-hook string        CertMagic obtained hook command
       --failed-hook string          CertMagic obtain failed hook command
-      --list-providers              List supported DNS providers
+  -l, --list-providers              List supported DNS providers
+      --eab-keyid string            ACME Custom EABKeyID
+      --eab-mackey string           ACME Custom EABHMACKey
   -h, --help                        help for dnsacme
+  -v, --version                     version for dnsacme
 ```
 
 ### DNS Config

--- a/acme.go
+++ b/acme.go
@@ -66,7 +66,14 @@ func Obtain(conf *Config) {
 
 	if conf.ZeroSSLCA {
 		issuer.CA = certmagic.ZeroSSLProductionCA
-		issuer.ExternalAccount = generateEABCredentials(conf.Email)
+		if len(conf.EABKeyID) > 0 && len(conf.EABHMACKey) > 0 {
+			issuer.ExternalAccount = &acme.EAB{
+				KeyID:  conf.EABKeyID,
+				MACKey: conf.EABHMACKey,
+			}
+		} else {
+			issuer.ExternalAccount = generateEABCredentials(conf.Email)
+		}
 	} else {
 		issuer.CA = certmagic.LetsEncryptProductionCA
 	}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var conf = Config{DNSConfig: make(map[string]string)}
 var rootCmd = &cobra.Command{
 	Use:     "dnsacme",
 	Short:   "Simple tool to manage ACME Cert(Ony Supported DNS-01)",
-	Example: "  dnsacme --domain='*.example.com' --dns=cloudflare --dns-config=CLOUDFLARE_API_TOKEN=xxxxxxxxxxxxxx",
+	Example: "  dnsacme --domain='*.example.com' --email='your.example.com' --dns=cloudflare --dns-config=CLOUDFLARE_API_TOKEN=xxxxxxxxxxxxxx",
 	Version: commit,
 	PreRun:  initConfig,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -56,7 +56,7 @@ func main() {
 
 func init() {
 	rootCmd.PersistentFlags().StringSliceP("domain", "d", nil, "ACME cert domains")
-	rootCmd.PersistentFlags().StringP("email", "m", "caddy@zerossl.com", "ACME email")
+	rootCmd.PersistentFlags().StringP("email", "m", "", "ACME email")
 	rootCmd.PersistentFlags().String("storage-dir", dataDir(), "ACME cert status storage directory")
 	rootCmd.PersistentFlags().StringP("key-type", "t", "P384", "ACME cert key type")
 	rootCmd.PersistentFlags().StringP("dns", "p", "", "ACME DNS provider")
@@ -66,6 +66,8 @@ func init() {
 	rootCmd.PersistentFlags().String("obtained-hook", "", "CertMagic obtained hook command")
 	rootCmd.PersistentFlags().String("failed-hook", "", "CertMagic obtain failed hook command")
 	rootCmd.PersistentFlags().BoolVarP(&listProviders, "list-providers", "l", false, "List supported DNS providers")
+	rootCmd.PersistentFlags().String("eab-keyid", "", "ACME Custom EABKeyID")
+	rootCmd.PersistentFlags().String("eab-mackey", "", "ACME Custom EABHMACKey")
 
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false
@@ -80,6 +82,8 @@ func init() {
 	_ = viper.BindEnv("obtaining-hook", "ACME_OBTAINING_HOOK")
 	_ = viper.BindEnv("obtained-hook", "ACME_OBTAINED_HOOK")
 	_ = viper.BindEnv("failed-hook", "ACME_FAILED_HOOK")
+	_ = viper.BindEnv("eab-keyid", "ACME_EABKEYID")
+	_ = viper.BindEnv("eab-mackey", "ACME_EABHMACKEY")
 
 	_ = viper.BindPFlags(rootCmd.PersistentFlags())
 
@@ -144,6 +148,8 @@ func initConfig(cmd *cobra.Command, _ []string) {
 	}
 
 	conf.ZeroSSLCA = viper.GetBool("zerossl")
+	conf.EABKeyID = viper.GetString("eab-keyid")
+	conf.EABHMACKey = viper.GetString("eab-mackey")
 
 	conf.ObtainingHook = viper.GetString("obtaining-hook")
 	if conf.ObtainingHook != "" && len(strings.Fields(conf.ObtainingHook)) != 1 {

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/caddyserver/certmagic"
+import (
+	"github.com/caddyserver/certmagic"
+)
 
 type Config struct {
 	Domains       []string
@@ -13,6 +15,11 @@ type Config struct {
 	ObtainingHook string
 	ObtainedHook  string
 	FailedHook    string
+
+	// 添加自定义EAB相关字段, ZeroSSLCA为true时有效, 将签发证书挂到zerossl指定账号下
+	// 具体参考https://app.zerossl.com/developer
+	EABKeyID   string // EAB Key Identifier
+	EABHMACKey string // EAB HMAC Key
 
 	keyType certmagic.KeyType
 }


### PR DESCRIPTION
- Update the email flag in the command usage example #42 
- Add support for external account binding by including EABKeyID and EABHMACKey